### PR TITLE
Rename geom to euclid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,10 @@ name = "io-surface"
 version = "0.1.0"
 authors = ["The Servo Project Developers"]
 
-[dependencies.geom]
-git = "https://github.com/servo/rust-geom"
-
 [dependencies]
 libc = "*"
 gleam = "0.1"
+euclid = "0.1"
 
 [target.x86_64-apple-darwin.dependencies]
 core-foundation = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 
 extern crate libc;
 extern crate core_foundation;
-extern crate geom;
+extern crate euclid;
 extern crate cgl;
 extern crate gleam;
 
@@ -23,7 +23,7 @@ extern crate gleam;
 use core_foundation::base::{CFRelease, CFRetain, CFTypeID, CFTypeRef, TCFType};
 use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
 use core_foundation::string::CFStringRef;
-use geom::size::Size2D;
+use euclid::size::Size2D;
 use cgl::{kCGLNoError, CGLGetCurrentContext, CGLTexImageIOSurface2D};
 use gleam::gl::{BGRA, GLenum, RGBA, TEXTURE_RECTANGLE_ARB, UNSIGNED_INT_8_8_8_8_REV};
 use libc::{c_int, c_void, size_t};


### PR DESCRIPTION
By the way, now it has no git deps, it can also be published to crates.io.