### PR TITLE
Set libc version to 0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 
 [dependencies]
-libc = "*"
+libc = "0.1"
 gleam = "0.1"
 euclid = "0.3"
 


### PR DESCRIPTION
This is necessary because libc 0.2 exists now and we need to have
all Servo dependencies using an explicit version.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/io-surface-rs/42)
<!-- Reviewable:end -->
