### PR TITLE
Print the error string when this fails, for the good of the debugger.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,6 @@ euclid = "0.4"
 
 [target.x86_64-apple-darwin.dependencies]
 core-foundation = "*"
-cgl = "0.1"
+cgl = "0.1.4"
+leaky-cow = "0.1.1"
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ extern crate core_foundation;
 extern crate euclid;
 extern crate cgl;
 extern crate gleam;
+extern crate leaky_cow;
 
 // Rust bindings to the IOSurface framework on Mac OS X.
 
@@ -24,11 +25,13 @@ use core_foundation::base::{CFRelease, CFRetain, CFTypeID, CFTypeRef, TCFType};
 use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
 use core_foundation::string::CFStringRef;
 use euclid::size::Size2D;
-use cgl::{kCGLNoError, CGLGetCurrentContext, CGLTexImageIOSurface2D};
+use cgl::{kCGLNoError, CGLGetCurrentContext, CGLTexImageIOSurface2D, CGLErrorString};
 use gleam::gl::{BGRA, GLenum, RGBA, TEXTURE_RECTANGLE_ARB, UNSIGNED_INT_8_8_8_8_REV};
 use libc::{c_int, c_void, size_t};
+use leaky_cow::LeakyCow;
 use std::mem;
 use std::slice;
+use std::ffi::CStr;
 
 
 //static kIOSurfaceLockReadOnly: u32 = 0x1;
@@ -135,7 +138,13 @@ impl IOSurface {
                                                   mem::transmute(self.as_concrete_TypeRef()),
                                                   0);
 
-            assert_eq!(gl_error, kCGLNoError);
+            if gl_error != kCGLNoError {
+                let error_msg = CStr::from_ptr(CGLErrorString(gl_error));
+                let error_msg = error_msg.to_string_lossy();
+                // This will only actually leak memory if error_msg is a `Cow::Owned`, which
+                // will only happen if the platform gives us invalid unicode.
+                panic!(error_msg.leak());
+            }
         }
     }
 


### PR DESCRIPTION
Note that I don't actually own a Mac, so I cannot test this on my own computer.

Also, it depends on a servo/cgl-rs#17.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/io-surface-rs/45)
<!-- Reviewable:end -->