### PR TITLE
Allow the texture format to be customized when binding an IOSurface to a texture.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "io-surface"
 description = "Bindings to IO Surface for OS X"
 homepage = "https://github.com/servo/io-surface-rs"
 repository = "https://github.com/servo/io-surface-rs"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ use core_foundation::base::{CFRelease, CFRetain, CFTypeID, CFTypeRef, TCFType};
 use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
 use core_foundation::string::CFStringRef;
 use cgl::{kCGLNoError, CGLGetCurrentContext, CGLTexImageIOSurface2D, CGLErrorString};
-use gleam::gl::{BGRA, GLenum, RGBA, TEXTURE_RECTANGLE_ARB, UNSIGNED_INT_8_8_8_8_REV};
+use gleam::gl::{GLenum, TEXTURE_RECTANGLE_ARB};
 use libc::{c_int, c_void, size_t};
 use leaky_cow::LeakyCow;
 use std::mem;
@@ -120,16 +120,25 @@ impl IOSurface {
     }
 
     /// Binds to the current GL texture.
-    pub fn bind_to_gl_texture(&self, width: i32, height: i32) {
+    ///
+    /// `internal_format`, `format`, and `gl_type` (corresponding to the `internalFormat`,
+    /// `format`, and `type` parameters on `glTexImage2D` respectively) must be one of the
+    /// supported combinations in the `<OpenGL/CGLIOSurface.h>` header in `OpenGL.framework`.
+    pub fn bind_to_gl_texture(&self,
+                              width: i32,
+                              height: i32,
+                              internal_format: GLenum,
+                              format: GLenum,
+                              gl_type: GLenum) {
         unsafe {
             let context = CGLGetCurrentContext();
             let gl_error = CGLTexImageIOSurface2D(context,
                                                   TEXTURE_RECTANGLE_ARB,
-                                                  RGBA as GLenum,
+                                                  internal_format,
                                                   width,
                                                   height,
-                                                  BGRA as GLenum,
-                                                  UNSIGNED_INT_8_8_8_8_REV,
+                                                  format,
+                                                  gl_type,
                                                   mem::transmute(self.as_concrete_TypeRef()),
                                                   0);
 


### PR DESCRIPTION
This is useful when rasterizing grayscale things like paths.

r? @nox

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/io-surface-rs/55)
<!-- Reviewable:end -->
