### PR TITLE
Upgrade core foundation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "io-surface"
 description = "Bindings to IO Surface for OS X"
 homepage = "https://github.com/servo/io-surface-rs"
 repository = "https://github.com/servo/io-surface-rs"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 
@@ -12,6 +12,6 @@ libc = "0.2"
 gleam = "0.4"
 
 [target.x86_64-apple-darwin.dependencies]
-core-foundation = "0.4"
+core-foundation = "0.5"
 cgl = "0.2.1"
 leaky-cow = "0.1.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,9 @@ impl Clone for IOSurface {
     }
 }
 
-impl TCFType<IOSurfaceRef> for IOSurface {
+impl TCFType for IOSurface {
+    type Ref = IOSurfaceRef;
+
     #[inline]
     fn as_concrete_TypeRef(&self) -> IOSurfaceRef {
         self.obj


### PR DESCRIPTION
This is a PR in a series of PRs originating at https://github.com/servo/core-foundation-rs/pull/132

The plan is to make a breaking change to `core-foundation` and release it as `0.5.0`. But before the merge/publish of `core-foundation` I will prepare a set of PRs making sure the entire dependency graph of Servo is ready for this change and can be switched over to `0.5.0` directly.

TODO before merge:
- [x] Merge `core-foundation` PR and publish.
- [x] Remove the last commit from this PR, so we depend on code from crates.io.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/io-surface-rs/60)
<!-- Reviewable:end -->
